### PR TITLE
Remove extra space line 65

### DIFF
--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -62,7 +62,7 @@
     {{- end -}}
     {{- end -}}
     <li>
-        <a href="#{{- $cleanedID  -}}" aria-label="{{- $header | plainify -}}">{{- $header | safeHTML -}}</a>
+        <a href="#{{- $cleanedID -}}" aria-label="{{- $header | plainify -}}">{{- $header | safeHTML -}}</a>
         {{- else -}}
     <li>
         <a href="#{{- $cleanedID -}}" aria-label="{{- $header | plainify -}}">{{- $header | safeHTML -}}</a>


### PR DESCRIPTION
Removes an extra space from line 65 causing issues on build. Example error below:

12:18:56 AM: Error: "/opt/build/repo/themes/hugo-PaperMod/layouts/partials/toc.html:65:1": parse failed: template: partials/toc.html:65: illegal number syntax: "-"